### PR TITLE
Fix [Function Configuration] "Image name" bubble info long text overflow

### DIFF
--- a/src/igz_controls/components/more-info/more-info.less
+++ b/src/igz_controls/components/more-info/more-info.less
@@ -70,6 +70,7 @@
         font-weight: 400;
         white-space: pre-line;
         line-height: normal;
+        overflow-wrap: break-word;
 
         &::before {
             position: absolute;


### PR DESCRIPTION
https://jira.iguazeng.com/browse/IG-20989

Before:
![image](https://user-images.githubusercontent.com/78905712/180759689-af3602de-cb59-4c50-9dc0-567b6dfbc19c.png)

After: 
![image](https://user-images.githubusercontent.com/78905712/180759670-92b40474-8687-48bd-aaf9-deab359a39f6.png)
