### PR TITLE
Fix [Nuclio] Log forwarder truncates long logs that do not contain spaces

### DIFF
--- a/src/igz_controls/components/log-table-row/log-table-row.less
+++ b/src/igz_controls/components/log-table-row/log-table-row.less
@@ -23,6 +23,7 @@
         }
 
         .log-entry-message {
+            line-break: anywhere;
             font-weight: 600;
         }
     }


### PR DESCRIPTION

http://iguazio.atlassian.net/browse/IG-23239